### PR TITLE
PILOT-3618: Improve how to update a refresh token

### DIFF
--- a/src/Grant/RefreshTokenGrant.php
+++ b/src/Grant/RefreshTokenGrant.php
@@ -21,6 +21,15 @@ use League\OAuth2\Server\Grant\RefreshTokenGrant as RefreshTokenGrantOriginal;
 
 /**
  * Refresh token grant
+ * 
+ * This class creates a new Refresh token and asign it to the user session. Per
+ * session we are going to have only one refresh token and with it you can
+ * create as many access tokens as required. Every time that you access the Api
+ * the expiration time of the refresh token will be delay by 45 minutes(depending on configuration)
+ * The expiration fo the Access Token is always the same and can't be extended,
+ * once it experices you will need to create a new one using the refresh token.
+ * If the refresh token has expired then you won't be able to create a new access
+ * token and because of that you will be redirected to the login page.
  */
 class RefreshTokenGrant extends RefreshTokenGrantOriginal
 {
@@ -29,18 +38,20 @@ class RefreshTokenGrant extends RefreshTokenGrantOriginal
      */
     public function completeFlow()
     {
+        // Get clientid from request
         $clientId = $this->server->getRequest()->request->get('client_id', $this->server->getRequest()->getUser());
         if (is_null($clientId)) {
             throw new Exception\InvalidRequestException('client_id');
         }
 
+        // Get client secret from request
         $clientSecret = $this->server->getRequest()->request->get('client_secret',
             $this->server->getRequest()->getPassword());
         if ($this->shouldRequireClientSecret() && is_null($clientSecret)) {
             throw new Exception\InvalidRequestException('client_secret');
         }
 
-        // Validate client ID and client secret
+        // Validate client ID and client secret and return the client.
         $client = $this->server->getClientStorage()->get(
             $clientId,
             $clientSecret,
@@ -53,6 +64,7 @@ class RefreshTokenGrant extends RefreshTokenGrantOriginal
             throw new Exception\InvalidClientException();
         }
 
+        // Gets the active refresh token for the current session.
         $oldRefreshTokenParam = $this->server->getRequest()->request->get('refresh_token', null);
         if ($oldRefreshTokenParam === null) {
             throw new Exception\InvalidRequestException('refresh_token');
@@ -69,6 +81,8 @@ class RefreshTokenGrant extends RefreshTokenGrantOriginal
             throw new Exception\InvalidRefreshException();
         }
         
+        // Using the expiration time of the current refresh token calculates the 
+        // reminding time for the new access token.
         $expireTime = $oldRefreshToken->getExpireTime();
         $remindingTime = $expireTime - time();
 
@@ -77,6 +91,7 @@ class RefreshTokenGrant extends RefreshTokenGrantOriginal
             throw new Exception\InvalidRefreshException();
         }
 
+        // It gets the previous access token.
         $oldAccessToken = $oldRefreshToken->getAccessToken();
 
         // Get the scopes for the original session
@@ -102,7 +117,7 @@ class RefreshTokenGrant extends RefreshTokenGrantOriginal
             $newScopes = $requestedScopes;
         }
 
-        // Generate a new access token and assign it the correct sessions
+        // Generate a new access token and assign it to the right sessions
         $newAccessToken = new AccessTokenEntity($this->server);
         $newAccessToken->setId(SecureKey::generate());
         $newAccessToken->setExpireTime($expireTime);
@@ -112,10 +127,13 @@ class RefreshTokenGrant extends RefreshTokenGrantOriginal
             $newAccessToken->associateScope($newScope);
         }
 
-        // Save the new one
+        // Save the new access token that is going to be returned to the user.
         $newAccessToken->save();
 
         // We need to assign the new access token to the current user session.
+        // The exipiration time should be reminding time on the current refresh token
+        // in that way event if you get a new access token a 10 seconds before the 
+        // refresh token expires the new access token will have only 10 seconds left.
         $this->server->getTokenType()->setSession($session);
         $this->server->getTokenType()->setParam('access_token', $newAccessToken->getId());
         $this->server->getTokenType()->setParam('expires_in', $remindingTime);

--- a/src/Grant/RefreshTokenGrant.php
+++ b/src/Grant/RefreshTokenGrant.php
@@ -112,8 +112,7 @@ class RefreshTokenGrant extends RefreshTokenGrantOriginal
             $newAccessToken->associateScope($newScope);
         }
 
-        // Expire the old token and save the new one
-        $oldAccessToken->expire();
+        // Save the new one
         $newAccessToken->save();
 
         $this->server->getTokenType()->setSession($session);
@@ -138,6 +137,10 @@ class RefreshTokenGrant extends RefreshTokenGrantOriginal
             $this->server->getTokenType()->setParam('refresh_token', $oldRefreshToken->getId());
         }
 
+        // Expire the old token
+        $oldAccessToken->expire();
+        
+        // Return a response
         return $this->server->getTokenType()->generateResponse();
     }
 }

--- a/src/Storage/FluentRefreshToken.php
+++ b/src/Storage/FluentRefreshToken.php
@@ -47,7 +47,7 @@ class FluentRefreshToken extends AbstractFluentAdapter implements RefreshTokenIn
     }
 
     /**
-     * Create or update a refresh token_name.
+     * Create or update a refresh token
      *
      * @param  string $token
      * @param  int $expireTime
@@ -57,10 +57,13 @@ class FluentRefreshToken extends AbstractFluentAdapter implements RefreshTokenIn
      */
     public function create($token, $expireTime, $accessToken)
     {
+        // We need to know if there is a record with the same token on the table.
         $refreshToken = $this->get($token);
 
+        // If the token already exits then update it, if not update the record.
         if( empty($refreshToken) )
         {
+            // Here we create a new refresh token
             $this->getConnection()->table('oauth_refresh_tokens')->insert([
                 'id' => $token,
                 'expire_time' => $expireTime,
@@ -71,6 +74,7 @@ class FluentRefreshToken extends AbstractFluentAdapter implements RefreshTokenIn
         }
         else
         {
+            // Update the refresh token that corresponds with the token.
             $this->getConnection()->table('oauth_refresh_tokens')
             ->where( 'id', $token )
             ->update([
@@ -80,6 +84,7 @@ class FluentRefreshToken extends AbstractFluentAdapter implements RefreshTokenIn
             ]);
         }
 
+        // We return a RefreshTokenEntity with the tokens data.
         return (new RefreshTokenEntity($this->getServer()))
                ->setId($token)
                ->setAccessTokenId($accessToken)

--- a/src/Storage/FluentRefreshToken.php
+++ b/src/Storage/FluentRefreshToken.php
@@ -47,7 +47,7 @@ class FluentRefreshToken extends AbstractFluentAdapter implements RefreshTokenIn
     }
 
     /**
-     * Create a new refresh token_name.
+     * Create or update a refresh token_name.
      *
      * @param  string $token
      * @param  int $expireTime
@@ -57,13 +57,28 @@ class FluentRefreshToken extends AbstractFluentAdapter implements RefreshTokenIn
      */
     public function create($token, $expireTime, $accessToken)
     {
-        $this->getConnection()->table('oauth_refresh_tokens')->insert([
-            'id' => $token,
-            'expire_time' => $expireTime,
-            'access_token_id' => $accessToken,
-            'created_at' => Carbon::now(),
-            'updated_at' => Carbon::now(),
-        ]);
+        $refreshToken = $this->get($token);
+
+        if( empty($refreshToken) )
+        {
+            $this->getConnection()->table('oauth_refresh_tokens')->insert([
+                'id' => $token,
+                'expire_time' => $expireTime,
+                'access_token_id' => $accessToken,
+                'created_at' => Carbon::now(),
+                'updated_at' => Carbon::now(),
+            ]);
+        }
+        else
+        {
+            $this->getConnection()->table('oauth_refresh_tokens')
+            ->where( 'id', $token )
+            ->update([
+                'expire_time' => $expireTime,
+                'access_token_id' => $accessToken,
+                'updated_at' => Carbon::now(),
+            ]);
+        }
 
         return (new RefreshTokenEntity($this->getServer()))
                ->setId($token)


### PR DESCRIPTION
We need to change the way we create a new access token. The refresh token should be updated before exipiring the old access token, in that way when you expire the old access token won't delete the refresh token. Because the we are not creating the refresh token every time we don't have the risk of trying to add the same refresh token.